### PR TITLE
add increment/decrement selections command (no interaction)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -75,6 +75,7 @@ function activate(context) {
 
   context.subscriptions.push(insertCmd);
   context.subscriptions.push(incrementCmd);
+  context.subscriptions.push(decrementCmd);
 }
 exports.activate = activate;
 

--- a/package.json
+++ b/package.json
@@ -19,14 +19,24 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:insertSequentialNumbers"
+    "onCommand:insertSequentialNumbers",
+    "onCommand:incrementSelections",
+    "onCommand:decrementSelections"
   ],
   "main": "./extension",
   "contributes": {
     "commands": [
       {
         "command": "insertSequentialNumbers",
-        "title": "Insert Sequential number"
+        "title": "input-sequence: Insert Sequential number"
+      },
+      {
+        "command": "incrementSelections",
+        "title": "input-sequence: Increment Selections"
+      },
+      {
+        "command": "decrementSelections",
+        "title": "input-sequence: Decrement Selections"
       }
     ],
     "configuration": {
@@ -43,6 +53,18 @@
         "command": "insertSequentialNumbers",
         "key": "ctrl+alt+0",
         "mac": "cmd+alt+0",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "incrementSelections",
+        "key": "ctrl+alt+i",
+        "mac": "cmd+alt+i",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "decrementSelections",
+        "key": "ctrl+alt+d",
+        "mac": "cmd+alt+d",
         "when": "editorTextFocus"
       }
     ]


### PR DESCRIPTION
I added the command that like "Increment Selection" extension on Sublime text.
https://github.com/yulanggong/IncrementSelection
Because I could not found a extension like "Increment Selection" in vscode extensions.