### PR TITLE
Add operator options to the tooltip

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -11,7 +11,7 @@ function activate(context) {
     var initialSelections = editor.selections.sort(sortSelection);
     var inputOptions = {};
     var undoStopBefore = true;
-    inputOptions.placeHolder = "<start> <operator> <step> : <digit> : <radix>";
+    inputOptions.placeHolder = "<start> <operator['+'|'-'|'++'|'--']> <step> : <digit> : <radix>";
     inputOptions.validateInput = function (param) {
       if (param === "") {
         perform(initialSelections, editor, {}, { undoStopBefore: undoStopBefore, undoStopAfter: false });
@@ -19,7 +19,7 @@ function activate(context) {
       }
       var test = parseInput(param);
       if (!test) {
-        return 'Syntax error. The rule is "<start> <operator> <step> : <digit> : <radix>".';
+        return 'Syntax error. The rule is "<start> <operator[\'+\'|\'-\'|\'++\'|\'--\']> <step> : <digit> : <radix>".';
       }
       // realtime simulate
       perform(initialSelections, editor, test, { undoStopBefore: undoStopBefore, undoStopAfter: false });


### PR DESCRIPTION
I think it might be helpful to show which operators you can enter. Specially helpful for newcomers or if you haven't used the extension for a long time and you forget the syntax.